### PR TITLE
Close cursor before finalizing

### DIFF
--- a/library/src/jp/co/cyberagent/android/gpuimage/GPUImage.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/GPUImage.java
@@ -489,7 +489,9 @@ public class GPUImage {
             }
 
             cursor.moveToFirst();
-            return cursor.getInt(0);
+            int orientation = cursor.getInt(0);
+            cursor.close();
+            return orientation;
         }
     }
 


### PR DESCRIPTION
GPUImage.getImageOrientation() doesn't close a used cursor properly which results in a warning. This fixes it.
