### PR TITLE
Fixed deadlock in getBitmapWithFilterApplied

### DIFF
--- a/library/src/jp/co/cyberagent/android/gpuimage/GPUImage.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/GPUImage.java
@@ -268,8 +268,8 @@ public class GPUImage {
                     }
                 }
             });
-            requestRender();
             synchronized(mFilter) {
+                requestRender();
                 try {
                     mFilter.wait();
                 } catch (InterruptedException e) {


### PR DESCRIPTION
There is a deadlock that occurs in getBitmapWithFilterApplied, on older devices.  The call to requestRender(), and the runnable that calls mFilter.notify() completes, before the calling thread can reach the mFilter.wait() on line 274.  Because mFilter.notify() has been called already, the call to wait() never completes.

This change means the synchronised block starting on line 265 will not run until the calling thread gives up the synchronized lock by calling mFilter.wait() on line 274.
