### PR TITLE
Fixed heavy cpu usage in getBitmapWithFilterApplied

### DIFF
--- a/library/src/jp/co/cyberagent/android/gpuimage/GPUImageView.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/GPUImageView.java
@@ -291,17 +291,18 @@ public class GPUImageView extends FrameLayout {
         final int height = mGLSurfaceView.getMeasuredHeight();
 
         // Take picture on OpenGL thread
-        final IntBuffer pixelMirroredBuffer = IntBuffer.allocate(width * height);
+        final int[] pixelMirroredArray = new int[width * height];
         mGPUImage.runOnGLThread(new Runnable() {
             @Override
             public void run() {
                 final IntBuffer pixelBuffer = IntBuffer.allocate(width * height);
                 GLES20.glReadPixels(0, 0, width, height, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, pixelBuffer);
+                int[] pixelArray = pixelBuffer.array();
 
                 // Convert upside down mirror-reversed image to right-side up normal image.
                 for (int i = 0; i < height; i++) {
                     for (int j = 0; j < width; j++) {
-                        pixelMirroredBuffer.put((height - i - 1) * width + j, pixelBuffer.get(i * width + j));
+                        pixelMirroredArray[(height - i - 1) * width + j] = pixelArray[i * width + j];
                     }
                 }
                 waiter.release();
@@ -311,7 +312,7 @@ public class GPUImageView extends FrameLayout {
         waiter.acquire();
 
         Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-        bitmap.copyPixelsFromBuffer(pixelMirroredBuffer);
+        bitmap.copyPixelsFromBuffer(IntBuffer.wrap(pixelMirroredArray));
         return bitmap;
     }
 

--- a/library/src/jp/co/cyberagent/android/gpuimage/PixelBuffer.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/PixelBuffer.java
@@ -189,19 +189,21 @@ public class PixelBuffer {
     }
 
     private void convertToBitmap() {
+        int[] iat = new int[mWidth * mHeight];
         IntBuffer ib = IntBuffer.allocate(mWidth * mHeight);
-        IntBuffer ibt = IntBuffer.allocate(mWidth * mHeight);
         mGL.glReadPixels(0, 0, mWidth, mHeight, GL_RGBA, GL_UNSIGNED_BYTE, ib);
+        int[] ia = ib.array();
 
         // Convert upside down mirror-reversed image to right-side up normal
         // image.
         for (int i = 0; i < mHeight; i++) {
             for (int j = 0; j < mWidth; j++) {
-                ibt.put((mHeight - i - 1) * mWidth + j, ib.get(i * mWidth + j));
+                iat[(mHeight - i - 1) * mWidth + j] = ia[i * mWidth + j];
             }
         }
+        
 
         mBitmap = Bitmap.createBitmap(mWidth, mHeight, Bitmap.Config.ARGB_8888);
-        mBitmap.copyPixelsFromBuffer(ibt);
+        mBitmap.copyPixelsFromBuffer(IntBuffer.wrap(iat));
     }
 }


### PR DESCRIPTION
In case of a large image, IntBuffer's get/put uses too many CPU resources as a whole.
Please merge the branch to fix it.
#### Code to Reproduce

``` java
GPUImage image = new GPUImage(this);
Bitmap srcBitmap = BitmapFactory.decodeResource(getResources(), R.raw.sample); // LARGE IMAGE!
image.setImage(srcBitmap);
image.setFilter(new GPUImageSepiaFilter());

Bitmap dstBitmap = image.getBitmapWithFilterApplied(); // HEAVY!
```

A simple activty to reproduce this problem is [here](https://github.com/amachang/android-gpuimage-sandbox/blob/master/src/jp/amachang/gpuimagesandbox/MainActivity.java#L31).
#### Profiling results (before fixing)

![before](https://raw.github.com/amachang/android-gpuimage-sandbox/master/tmp/before.png)
#### Profiling results (fixed)

![after](https://raw.github.com/amachang/android-gpuimage-sandbox/master/tmp/after.png)
