### PR TITLE
updated chromakey blend filter

### DIFF
--- a/library/src/jp/co/cyberagent/android/gpuimage/GPUImage.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/GPUImage.java
@@ -25,6 +25,7 @@ import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
+import android.graphics.PixelFormat;
 import android.hardware.Camera;
 import android.media.ExifInterface;
 import android.media.MediaScannerConnection;
@@ -93,6 +94,8 @@ public class GPUImage {
     public void setGLSurfaceView(final GLSurfaceView view) {
         mGlSurfaceView = view;
         mGlSurfaceView.setEGLContextClientVersion(2);
+        mGlSurfaceView.setEGLConfigChooser(8, 8, 8, 8, 16, 0);
+        mGlSurfaceView.getHolder().setFormat(PixelFormat.RGBA_8888);
         mGlSurfaceView.setRenderer(mRenderer);
         mGlSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
         mGlSurfaceView.requestRender();

--- a/library/src/jp/co/cyberagent/android/gpuimage/GPUImageChromaKeyBlendFilter.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/GPUImageChromaKeyBlendFilter.java
@@ -17,59 +17,47 @@
 package jp.co.cyberagent.android.gpuimage;
 
 import android.opengl.GLES20;
+import android.util.Log;
 
 /**
  * Selectively replaces a color in the first image with the second image
  */
 public class GPUImageChromaKeyBlendFilter extends GPUImageTwoInputFilter {
-    public static final String CHROMA_KEY_BLEND_FRAGMENT_SHADER = "varying highp vec2 textureCoordinate;\n" +
-            " varying highp vec2 textureCoordinate2;\n" +
-            " \n" +
-            " uniform sampler2D inputImageTexture;\n" +
-            " uniform sampler2D inputImageTexture2;\n" +
-            " \n" +
-            " highp float lum(lowp vec3 c) {\n" +
-            "     return dot(c, vec3(0.3, 0.59, 0.11));\n" +
-            " }\n" +
-            " \n" +
-            " lowp vec3 clipcolor(lowp vec3 c) {\n" +
-            "     highp float l = lum(c);\n" +
-            "     lowp float n = min(min(c.r, c.g), c.b);\n" +
-            "     lowp float x = max(max(c.r, c.g), c.b);\n" +
-            "     \n" +
-            "     if (n < 0.0) {\n" +
-            "         c.r = l + ((c.r - l) * l) / (l - n);\n" +
-            "         c.g = l + ((c.g - l) * l) / (l - n);\n" +
-            "         c.b = l + ((c.b - l) * l) / (l - n);\n" +
-            "     }\n" +
-            "     if (x > 1.0) {\n" +
-            "         c.r = l + ((c.r - l) * (1.0 - l)) / (x - l);\n" +
-            "         c.g = l + ((c.g - l) * (1.0 - l)) / (x - l);\n" +
-            "         c.b = l + ((c.b - l) * (1.0 - l)) / (x - l);\n" +
-            "     }\n" +
-            "     \n" +
-            "     return c;\n" +
-            " }\n" +
-            "\n" +
-            " lowp vec3 setlum(lowp vec3 c, highp float l) {\n" +
-            "     highp float d = l - lum(c);\n" +
-            "     c = c + vec3(d);\n" +
-            "     return clipcolor(c);\n" +
-            " }\n" +
-            " \n" +
-            " void main()\n" +
-            " {\n" +
-            "   highp vec4 baseColor = texture2D(inputImageTexture, textureCoordinate);\n" +
-            "   highp vec4 overlayColor = texture2D(inputImageTexture2, textureCoordinate2);\n" +
-            "\n" +
-            "     gl_FragColor = vec4(baseColor.rgb * (1.0 - overlayColor.a) + setlum(overlayColor.rgb, lum(baseColor.rgb)) * overlayColor.a, baseColor.a);\n" +
-            " }";
+    public static final String CHROMA_KEY_BLEND_FRAGMENT_SHADER = "precision highp float;\n" +
+    		"\n" +
+    		" varying highp vec2 textureCoordinate;\n" +
+    		" varying highp vec2 textureCoordinate2;\n" +
+    		"\n" +
+    		" uniform float thresholdSensitivity;\n" +
+    		" uniform float smoothing;\n" +
+    		" uniform vec3 colorToReplace;\n" +
+    		" uniform sampler2D inputImageTexture;\n" +
+    		" uniform sampler2D inputImageTexture2;\n" +
+    		"\n" +
+    		" void main()\n" +
+    		" {\n" +
+    		"     vec4 textureColor = texture2D(inputImageTexture, textureCoordinate);\n" +
+    		"     vec4 textureColor2 = texture2D(inputImageTexture2, textureCoordinate2);\n" +
+    		"\n" +
+    		"     float maskY = 0.2989 * colorToReplace.r + 0.5866 * colorToReplace.g + 0.1145 * colorToReplace.b;\n" +
+    		"     float maskCr = 0.7132 * (colorToReplace.r - maskY);\n" +
+    		"     float maskCb = 0.5647 * (colorToReplace.b - maskY);\n" +
+    		"\n" +
+    		"     float Y = 0.2989 * textureColor.r + 0.5866 * textureColor.g + 0.1145 * textureColor.b;\n" +
+    		"     float Cr = 0.7132 * (textureColor.r - Y);\n" +
+    		"     float Cb = 0.5647 * (textureColor.b - Y);\n" +
+    		"\n" +
+    		"//     float blendValue = 1.0 - smoothstep(thresholdSensitivity - smoothing, thresholdSensitivity , abs(Cr - maskCr) + abs(Cb - maskCb));\n" +
+    		"     float blendValue = 1.0 - smoothstep(thresholdSensitivity, thresholdSensitivity + smoothing, distance(vec2(Cr, Cb), vec2(maskCr, maskCb)));\n" +
+    		"     gl_FragColor = mix(textureColor, textureColor2, blendValue);\n" +
+    		" }\n"
+;
 
     private int mThresholdSensitivityLocation;
     private int mSmoothingLocation;
     private int mColorToReplaceLocation;
     private float mSmoothing = 0.1f;
-    private float mThresholdSensitivity = 0.3f;
+    private float mThresholdSensitivity = 0.4f;
     private float[] mColorToReplace = new float[]{0.0f, 1.0f, 0.0f};
 
     public GPUImageChromaKeyBlendFilter() {
@@ -91,6 +79,14 @@ public class GPUImageChromaKeyBlendFilter extends GPUImageTwoInputFilter {
         setSmoothing(mSmoothing);
         setThresholdSensitivity(mThresholdSensitivity);
         setColorToReplace(mColorToReplace[0], mColorToReplace[1], mColorToReplace[2]);
+    }
+    
+    @Override
+    protected void onDrawArraysPre() {
+    	super.onDrawArraysPre();    	
+    	setFloat(mSmoothingLocation, mSmoothing);
+    	setFloat(mThresholdSensitivityLocation, mThresholdSensitivity);
+    	setFloatVec3(mColorToReplaceLocation, mColorToReplace);
     }
 
     /**

--- a/sample/src/jp/co/cyberagent/android/gpuimage/sample/GPUImageFilterTools.java
+++ b/sample/src/jp/co/cyberagent/android/gpuimage/sample/GPUImageFilterTools.java
@@ -297,6 +297,8 @@ public class GPUImageFilterTools {
                 adjuster = new VignetteAdjuster().filter(filter);
             } else if (filter instanceof GPUImageDissolveBlendFilter) {
                 adjuster = new DissolveBlendAdjuster().filter(filter);
+            } else if (filter instanceof GPUImageChromaKeyBlendFilter) {
+                adjuster = new ChromaKeyBlendAdjuster().filter(filter);
             } else {
                 adjuster = null;
             }
@@ -475,6 +477,13 @@ public class GPUImageFilterTools {
             @Override
             public void adjust(final int percentage) {
                 getFilter().setMix(range(percentage, 0.0f, 1.0f));
+            }
+        }
+        
+        private class ChromaKeyBlendAdjuster extends Adjuster<GPUImageChromaKeyBlendFilter> {
+            @Override
+            public void adjust(final int percentage) {
+                getFilter().setThresholdSensitivity(range(percentage, 0.2f, 0.6f));
             }
         }
     }


### PR DESCRIPTION
the chromakey blend filter taken from the iOS version wasn't fully ported correctly. it was using the wrong fragment shader. also - added filter tool updates to use the slider with the threshold value for simple sliding, updated the base threshold to 0.4 (on 0.3 the green screen testing i did looked like it was broken and slider wasnt working so i was pounding my head for days haha)

additionally in GPUImage you should consider putting a getter for the surfaceview since i couldnt set other properties like the pixel format etc, so i just put the base ones for RGBA8888 in the init call.
