### PR TITLE
Fix render error when displaying GPUImageView

### DIFF
--- a/library/src/jp/co/cyberagent/android/gpuimage/GPUImageView.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/GPUImageView.java
@@ -59,8 +59,11 @@ public class GPUImageView extends FrameLayout {
     private void init(Context context, AttributeSet attrs) {
         mGLSurfaceView = new GPUImageGLSurfaceView(context, attrs);
         addView(mGLSurfaceView);
-        mGPUImage = new GPUImage(getContext());
-        mGPUImage.setGLSurfaceView(mGLSurfaceView);
+
+        if (!isInEditMode()) {
+            mGPUImage = new GPUImage(getContext());
+            mGPUImage.setGLSurfaceView(mGLSurfaceView);
+        }
     }
 
     @Override


### PR DESCRIPTION
The editor's preview crashes when calling `init()`, this simply checks if it's rendering in the editor and if it is it wont execute that code.
