### PR TITLE
Allow setting the background color

### DIFF
--- a/library/src/jp/co/cyberagent/android/gpuimage/GPUImage.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/GPUImage.java
@@ -101,6 +101,17 @@ public class GPUImage {
     }
 
     /**
+     * Sets the background color
+     *
+     * @param red red color value
+     * @param green green color value
+     * @param blue red color value
+     */
+    public void setBackgroundColor(float red, float green, float blue) {
+        mRenderer.setBackgroundColor(red, green, blue);
+    }
+
+    /**
      * Request the preview to be rendered again.
      */
     public void requestRender() {

--- a/library/src/jp/co/cyberagent/android/gpuimage/GPUImageRenderer.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/GPUImageRenderer.java
@@ -73,6 +73,10 @@ public class GPUImageRenderer implements Renderer, PreviewCallback {
     private boolean mFlipVertical;
     private GPUImage.ScaleType mScaleType = GPUImage.ScaleType.CENTER_CROP;
 
+    private float mBackgroundRed = 0;
+    private float mBackgroundGreen = 0;
+    private float mBackgroundBlue = 0;
+
     public GPUImageRenderer(final GPUImageFilter filter) {
         mFilter = filter;
         mRunOnDraw = new LinkedList<Runnable>();
@@ -91,7 +95,7 @@ public class GPUImageRenderer implements Renderer, PreviewCallback {
 
     @Override
     public void onSurfaceCreated(final GL10 unused, final EGLConfig config) {
-        GLES20.glClearColor(0, 0, 0, 1);
+        GLES20.glClearColor(mBackgroundRed, mBackgroundGreen, mBackgroundBlue, 1);
         GLES20.glDisable(GLES20.GL_DEPTH_TEST);
         mFilter.init();
     }
@@ -118,6 +122,19 @@ public class GPUImageRenderer implements Renderer, PreviewCallback {
         if (mSurfaceTexture != null) {
             mSurfaceTexture.updateTexImage();
         }
+    }
+
+    /**
+     * Sets the background color
+     *
+     * @param red red color value
+     * @param green green color value
+     * @param blue red color value
+     */
+    public void setBackgroundColor(float red, float green, float blue) {
+        mBackgroundRed = red;
+        mBackgroundGreen = green;
+        mBackgroundBlue = blue;
     }
 
     private void runAll(Queue<Runnable> queue) {

--- a/library/src/jp/co/cyberagent/android/gpuimage/GPUImageRenderer.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/GPUImageRenderer.java
@@ -91,10 +91,8 @@ public class GPUImageRenderer implements Renderer, PreviewCallback {
 
     @Override
     public void onSurfaceCreated(final GL10 unused, final EGLConfig config) {
-        GLES20.glDisable(GL10.GL_DITHER);
-        GLES20.glClearColor(0,0,0,0);
-        GLES20.glEnable(GL10.GL_CULL_FACE);
-        GLES20.glEnable(GL10.GL_DEPTH_TEST);
+        GLES20.glClearColor(0, 0, 0, 1);
+        GLES20.glDisable(GLES20.GL_DEPTH_TEST);
         mFilter.init();
     }
 

--- a/library/src/jp/co/cyberagent/android/gpuimage/GPUImageView.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/GPUImageView.java
@@ -19,6 +19,8 @@ package jp.co.cyberagent.android.gpuimage;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.opengl.GLES20;
@@ -92,6 +94,17 @@ public class GPUImageView extends FrameLayout {
      */
     public GPUImage getGPUImage() {
         return mGPUImage;
+    }
+
+    /**
+     * Sets the background color
+     *
+     * @param red red color value
+     * @param green green color value
+     * @param blue red color value
+     */
+    public void setBackgroundColor(float red, float green, float blue) {
+        mGPUImage.setBackgroundColor(red, green, blue);
     }
 
     // TODO Should be an xml attribute. But then GPUImage can not be distributed as .jar anymore.

--- a/library/src/jp/co/cyberagent/android/gpuimage/GPUImageView.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/GPUImageView.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.media.MediaScannerConnection;
-import android.graphics.PixelFormat;
 import android.net.Uri;
 import android.opengl.GLES20;
 import android.opengl.GLSurfaceView;
@@ -57,9 +56,6 @@ public class GPUImageView extends FrameLayout {
 
     private void init(Context context, AttributeSet attrs) {
         mGLSurfaceView = new GPUImageGLSurfaceView(context, attrs);
-        mGLSurfaceView.setZOrderOnTop(true);
-        mGLSurfaceView.setEGLConfigChooser(8, 8, 8, 8, 16, 0);
-        mGLSurfaceView.getHolder().setFormat(PixelFormat.TRANSPARENT);
         addView(mGLSurfaceView);
         mGPUImage = new GPUImage(getContext());
         mGPUImage.setGLSurfaceView(mGLSurfaceView);


### PR DESCRIPTION
The last PR set the background to transparent (https://github.com/CyberAgent/android-gpuimage/commit/28f785ac211b038d3c41cee29d42d25c9f736dd7), but this wasn't a very good idea because it forces the view to be always on top (it changes the Z value).

I think that allowing to set the background color to any value is a better approach, so this PR reverts the previous commit and adds this functionality.

Sorry for sending the first PR on the first place
