### PR TITLE
Handle android asset uris

### DIFF
--- a/library/src/jp/co/cyberagent/android/gpuimage/GPUImage.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/GPUImage.java
@@ -44,6 +44,8 @@ import java.net.URL;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 
+import jp.co.cyberagent.android.gpuimage.util.AssetsUtil;
+
 /**
  * The main accessor for GPUImage functionality. This class helps to do common
  * tasks through a simple interface.
@@ -483,6 +485,8 @@ public class GPUImage {
                 InputStream inputStream;
                 if (mUri.getScheme().startsWith("http") || mUri.getScheme().startsWith("https")) {
                     inputStream = new URL(mUri.toString()).openStream();
+                } else if (AssetsUtil.isAssetUri(mUri)) {
+                    inputStream = mContext.getAssets().open(AssetsUtil.getFilePath(mUri));
                 } else {
                     inputStream = mContext.getContentResolver().openInputStream(mUri);
                 }

--- a/library/src/jp/co/cyberagent/android/gpuimage/util/AssetsUtil.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/util/AssetsUtil.java
@@ -1,0 +1,21 @@
+package jp.co.cyberagent.android.gpuimage.util;
+
+import android.net.Uri;
+
+import static android.content.ContentResolver.SCHEME_FILE;
+
+public class AssetsUtil {
+    private static final String ANDROID_ASSET = "android_asset";
+    private static final int ASSET_PREFIX_LENGTH =
+        (SCHEME_FILE + ":///" + ANDROID_ASSET + "/").length();
+
+    public static boolean isAssetUri(Uri uri) {
+        return SCHEME_FILE.equals(uri.getScheme())
+            && !uri.getPathSegments().isEmpty()
+            && ANDROID_ASSET.equals(uri.getPathSegments().get(0));
+    }
+
+    public static String getFilePath(Uri assetUri) {
+        return assetUri.toString().substring(ASSET_PREFIX_LENGTH);
+    }
+}


### PR DESCRIPTION
Allows Uris of images stored in the assets folder to be passed into setImage().
Currently, ContentResolver will fail on asset Uris with an ENOENT- no such file. See https://code.google.com/p/android/issues/detail?id=42675

Inspired by Picasso's handling of this issue:
https://github.com/square/picasso/blob/master/picasso/src/main/java/com/squareup/picasso/AssetRequestHandler.java
