### PR TITLE
Fix camera preview in Android 8.0.0 or higher

### DIFF
--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImage.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImage.java
@@ -144,8 +144,7 @@ public class GPUImage {
     public void setUpCamera(final Camera camera, final int degrees, final boolean flipHorizontal,
                             final boolean flipVertical) {
         mGlSurfaceView.setRenderMode(GLSurfaceView.RENDERMODE_CONTINUOUSLY);
-        camera.setPreviewCallback(mRenderer);
-        camera.startPreview();
+        mRenderer.setUpSurfaceTexture(camera);
         Rotation rotation = Rotation.NORMAL;
         switch (degrees) {
             case 90:


### PR DESCRIPTION
## What does this change?
- Call GPUImageRenderer#setUpSurfaceTexture() to set surfaceTexture before starting preview.

## What is the value of this and can you measure success?
- Preview camera sample in Android 8.0.0 or higher.

## Screenshots 
![device-2018-10-16-164449](https://user-images.githubusercontent.com/24409457/47000290-e8f26500-d162-11e8-8318-f37d86da33cb.png)

