### PR TITLE
 Assertion filter is initialized.

### DIFF
--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageFilter.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageFilter.java
@@ -72,7 +72,6 @@ public class GPUImageFilter {
 
     public final void init() {
         onInit();
-        isInitialized = true;
         onInitialized();
     }
 
@@ -167,6 +166,8 @@ public class GPUImageFilter {
     }
 
     protected void setInteger(final int location, final int intValue) {
+        checkIsInitialized();
+        
         runOnDraw(new Runnable() {
             @Override
             public void run() {
@@ -176,6 +177,8 @@ public class GPUImageFilter {
     }
 
     protected void setFloat(final int location, final float floatValue) {
+        checkIsInitialized();
+        
         runOnDraw(new Runnable() {
             @Override
             public void run() {
@@ -185,6 +188,8 @@ public class GPUImageFilter {
     }
 
     protected void setFloatVec2(final int location, final float[] arrayValue) {
+        checkIsInitialized();
+        
         runOnDraw(new Runnable() {
             @Override
             public void run() {
@@ -194,6 +199,8 @@ public class GPUImageFilter {
     }
 
     protected void setFloatVec3(final int location, final float[] arrayValue) {
+        checkIsInitialized();
+        
         runOnDraw(new Runnable() {
             @Override
             public void run() {
@@ -203,6 +210,8 @@ public class GPUImageFilter {
     }
 
     protected void setFloatVec4(final int location, final float[] arrayValue) {
+        checkIsInitialized();
+        
         runOnDraw(new Runnable() {
             @Override
             public void run() {
@@ -212,6 +221,8 @@ public class GPUImageFilter {
     }
 
     protected void setFloatArray(final int location, final float[] arrayValue) {
+        checkIsInitialized();
+        
         runOnDraw(new Runnable() {
             @Override
             public void run() {
@@ -221,6 +232,8 @@ public class GPUImageFilter {
     }
 
     protected void setPoint(final int location, final PointF point) {
+        checkIsInitialized();
+        
         runOnDraw(new Runnable() {
 
             @Override
@@ -234,6 +247,8 @@ public class GPUImageFilter {
     }
 
     protected void setUniformMatrix3f(final int location, final float[] matrix) {
+        checkIsInitialized();
+        
         runOnDraw(new Runnable() {
 
             @Override
@@ -244,6 +259,8 @@ public class GPUImageFilter {
     }
 
     protected void setUniformMatrix4f(final int location, final float[] matrix) {
+        checkIsInitialized();
+        
         runOnDraw(new Runnable() {
 
             @Override
@@ -277,5 +294,11 @@ public class GPUImageFilter {
     public static String convertStreamToString(java.io.InputStream is) {
         java.util.Scanner s = new java.util.Scanner(is).useDelimiter("\\A");
         return s.hasNext() ? s.next() : "";
+    }
+    
+    private void checkIsInitialized() {
+        if (!mInInitialized) {
+            throw new AssertionError("Filter should be initialized");
+        }
     }
 }

--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageFilter.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageFilter.java
@@ -297,7 +297,7 @@ public class GPUImageFilter {
     }
     
     private void checkIsInitialized() {
-        if (!mIsInitialized) {
+        if (!isInitialized) {
             throw new AssertionError("Filter should be initialized");
         }
     }

--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageFilter.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageFilter.java
@@ -297,7 +297,7 @@ public class GPUImageFilter {
     }
     
     private void checkIsInitialized() {
-        if (!mInInitialized) {
+        if (!mIsInitialized) {
             throw new AssertionError("Filter should be initialized");
         }
     }


### PR DESCRIPTION
## What does this change?

Check the filter is initialized before process `setX` function.

## What is the value of this and can you measure success?

The value of `location` argument should be wrong if this setX method called before the filter is initialized because we cannot know valid `location` before the filter is initialized. 

I think we should force us to initialize the filter before set their variables.

I found a bug of GPUImageTransformFilter at first. That filter calls their `setUniformMatrix4f` with wrong `location` before their initialization is completed, and then the pending operation always fail on first onDraw.

I tried to fix the bug on GPUImageTransformFilter.java, but I noticed the underlying problem is on GPUImageFilter.java.

If you merge this PR, Hidden bugs may begin to surface but I think they should be fixed asap regardless of whether this PR is merged or not.

