### PR TITLE
Fix camera2 preview

### DIFF
--- a/sample/src/main/java/jp/co/cyberagent/android/gpuimage/sample/utils/Camera2Loader.kt
+++ b/sample/src/main/java/jp/co/cyberagent/android/gpuimage/sample/utils/Camera2Loader.kt
@@ -5,7 +5,6 @@ import android.app.Activity
 import android.content.Context
 import android.graphics.ImageFormat
 import android.hardware.camera2.*
-import android.media.Image
 import android.media.ImageReader
 import android.os.Build
 import android.util.Log
@@ -100,7 +99,7 @@ class Camera2Loader(private val activity: Activity) : CameraLoader() {
                 ImageReader.newInstance(size.width, size.height, ImageFormat.YUV_420_888, 2).apply {
                     setOnImageAvailableListener({ reader ->
                         val image = reader?.acquireNextImage() ?: return@setOnImageAvailableListener
-                        onPreviewFrame?.invoke(generateNV21Data(image), image.width, image.height)
+                        onPreviewFrame?.invoke(image.generateNV21Data(), image.width, image.height)
                         image.close()
                     }, null)
                 }
@@ -130,20 +129,6 @@ class Camera2Loader(private val activity: Activity) : CameraLoader() {
         }?.maxBy {
             it.width * it.height
         } ?: Size(PREVIEW_WIDTH, PREVIEW_HEIGHT)
-    }
-
-    private fun generateNV21Data(image: Image): ByteArray {
-        val bufferY = image.planes[0].buffer
-        val bufferV = image.planes[1].buffer
-        val bufferU = image.planes[2].buffer
-        val bufferYSize = bufferY.remaining()
-        val bufferUSize = bufferU.remaining()
-        val bufferVSize = bufferV.remaining()
-        val bytes = ByteArray(bufferYSize + bufferUSize + bufferVSize)
-        bufferY.get(bytes, 0, bufferYSize)
-        bufferU.get(bytes, bufferYSize, bufferUSize)
-        bufferV.get(bytes, bufferYSize + bufferUSize, bufferVSize)
-        return bytes
     }
 
     private inner class CameraDeviceCallback : CameraDevice.StateCallback() {

--- a/sample/src/main/java/jp/co/cyberagent/android/gpuimage/sample/utils/Camera2Loader.kt
+++ b/sample/src/main/java/jp/co/cyberagent/android/gpuimage/sample/utils/Camera2Loader.kt
@@ -124,8 +124,12 @@ class Camera2Loader(private val activity: Activity) : CameraLoader() {
             .get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
             ?.getOutputSizes(ImageFormat.YUV_420_888)
 
+        val orientation = getCameraOrientation()
+        val maxPreviewWidth = if (orientation == 90 or 270) viewHeight else viewWidth
+        val maxPreviewHeight = if (orientation == 90 or 270) viewWidth else viewHeight
+
         return outputSizes?.filter {
-            it.width < viewWidth / 2 && it.height < viewHeight / 2
+            it.width < maxPreviewWidth / 2 && it.height < maxPreviewHeight / 2
         }?.maxBy {
             it.width * it.height
         } ?: Size(PREVIEW_WIDTH, PREVIEW_HEIGHT)

--- a/sample/src/main/java/jp/co/cyberagent/android/gpuimage/sample/utils/ImageExt.kt
+++ b/sample/src/main/java/jp/co/cyberagent/android/gpuimage/sample/utils/ImageExt.kt
@@ -1,0 +1,61 @@
+package jp.co.cyberagent.android.gpuimage.sample.utils
+
+import android.graphics.ImageFormat
+import android.media.Image
+import android.os.Build
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+fun Image.generateNV21Data(): ByteArray {
+    val crop = cropRect
+    val format = format
+    val width = crop.width()
+    val height = crop.height()
+    val planes = planes
+    val data = ByteArray(width * height * ImageFormat.getBitsPerPixel(format) / 8)
+    val rowData = ByteArray(planes[0].rowStride)
+    var channelOffset = 0
+    var outputStride = 1
+    for (i in planes.indices) {
+        when (i) {
+            0 -> {
+                channelOffset = 0
+                outputStride = 1
+            }
+            1 -> {
+                channelOffset = width * height + 1
+                outputStride = 2
+            }
+            2 -> {
+                channelOffset = width * height
+                outputStride = 2
+            }
+        }
+        val buffer = planes[i].buffer
+        val rowStride = planes[i].rowStride
+        val pixelStride = planes[i].pixelStride
+        val shift = if (i == 0) 0 else 1
+        val w = width shr shift
+        val h = height shr shift
+        buffer.position(rowStride * (crop.top shr shift) + pixelStride * (crop.left shr shift))
+        for (row in 0 until h) {
+            val length: Int
+            if (pixelStride == 1 && outputStride == 1) {
+                length = w
+                buffer.get(data, channelOffset, length)
+                channelOffset += length
+            } else {
+                length = (w - 1) * pixelStride + 1
+                buffer.get(rowData, 0, length)
+                for (col in 0 until w) {
+                    data[channelOffset] = rowData[col * pixelStride]
+                    channelOffset += outputStride
+                }
+            }
+            if (row < h - 1) {
+                buffer.position(buffer.position() + rowStride - length)
+            }
+        }
+    }
+    return data
+}


### PR DESCRIPTION
## What does this change?
Fix https://github.com/cats-oss/android-gpuimage/issues/429

## What is the value of this and can you measure success?
Can properly preview

## Screenshots

|before|after|
|-|-|
| ![device-2018-11-07-190630](https://user-images.githubusercontent.com/24409457/48124788-84897800-e2c0-11e8-92c0-b665d89c0e4f.png) | ![device-2018-11-07-190538](https://user-images.githubusercontent.com/24409457/48124809-90753a00-e2c0-11e8-8196-d3a801336d84.png) |



