### PR TITLE
Fix GPUImageView.capture(int, int) when show_loading attribute is false

### DIFF
--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImageView.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImageView.java
@@ -344,16 +344,17 @@ public class GPUImageView extends FrameLayout {
             }
         });
 
-        if (isShowLoading) {
-            post(new Runnable() {
-                @Override
-                public void run() {
-                    // Show loading
+        post(new Runnable() {
+            @Override
+            public void run() {
+                // Optionally, show loading view:
+                if (isShowLoading) {
                     addView(new LoadingView(getContext()));
-                    surfaceView.requestLayout();
                 }
-            });
-        }
+                // Request layout to release waiter:
+                surfaceView.requestLayout();
+            }
+        });
 
         waiter.acquire();
 


### PR DESCRIPTION
Fixing https://github.com/cats-oss/android-gpuimage/issues/432. surfaceView.requestLayout should be called, no matter whether you show LoadingView or not, otherwise "forceSize" is not applied to the surface.

## What does this change?

## What is the value of this and can you measure success?

## Screenshots

