### PR TITLE
make sure the runOnDraw operation is thread-safe

### DIFF
--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageFilter.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageFilter.java
@@ -135,8 +135,10 @@ public class GPUImageFilter {
     }
 
     protected void runPendingOnDrawTasks() {
-        while (!runOnDraw.isEmpty()) {
-            runOnDraw.removeFirst().run();
+        synchronized (runOnDraw) {
+            while (!runOnDraw.isEmpty()) {
+                runOnDraw.removeFirst().run();
+            }
         }
     }
 


### PR DESCRIPTION
## What does this change?
make sure the GPUImageFilter.runOnDraw operation is thread-safe

## What is the value of this and can you measure success?
Reduce the runtime crashes.
crash log : http://crashes.to/s/67ca97df38a

## Screenshots
N/a
