### PR TITLE
Get size of rescaled image

### DIFF
--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImage.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImage.java
@@ -261,7 +261,7 @@ public class GPUImage {
      * @return array with width and height of bitmap image
      */
     public int[] getScaleSize() {
-        return new int[] = {scaleWidth, scaleHeight};
+        return new int[] {scaleWidth, scaleHeight};
     }
 
     /**

--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImage.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImage.java
@@ -67,6 +67,7 @@ public class GPUImage {
     private GPUImageFilter filter;
     private Bitmap currentBitmap;
     private ScaleType scaleType = ScaleType.CENTER_CROP;
+    private int scaleWidth, scaleHeight;
 
     /**
      * Instantiates a new GPUImage object.
@@ -249,6 +250,18 @@ public class GPUImage {
         renderer.deleteImage();
         currentBitmap = null;
         requestRender();
+    }
+
+    /**
+     * This gets the size of the image. This makes it easier to adjust
+     * the size of your imagePreview to the the size of the scaled image.
+     *
+     * @param width The bitmap width
+     * @param height The bitmap height
+     * @return array with width and height of bitmap image
+     */
+    public int[] getScaleSize() {
+        return new int[] = {scaleWidth, scaleHeight};
     }
 
     /**
@@ -729,6 +742,8 @@ public class GPUImage {
                 newWidth = outputWidth;
                 newHeight = (newWidth / width) * height;
             }
+            scaleWidth = Math.round(newWidth);
+            scaleHeight = Math.round(newHeight);
             return new int[]{Math.round(newWidth), Math.round(newHeight)};
         }
 


### PR DESCRIPTION
## What does this change?
Added a method to return the size of the rescaled image

## What is the value of this and can you measure success?
While working I wasn't able to easily resize the image view to fit the image without black area so I found it easier if you could just get the width and height of bitmap returned to you

## Screenshots

