### PR TITLE
Add wide range filters for adjusts the shadows and highlights of an i…

### DIFF
--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageHighlightShadowWideRangeFilter.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageHighlightShadowWideRangeFilter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2018 CyberAgent, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jp.co.cyberagent.android.gpuimage.filter;
+
+import android.opengl.GLES20;
+
+/**
+ * Adjusts the shadows and highlights of an image
+ * shadows: Increase to lighten shadows, from 0.0 to 2.0, with 1.0 as the default.
+ * highlights: Decrease to darken highlights, from 0.0 to 2.0, with 1.0 as the default.
+ */
+public class GPUImageHighlightShadowWideRangeFilter extends GPUImageFilter {
+
+    public static final String HIGHLIGHT_SHADOW_FRAGMENT_SHADER = "" +
+            " uniform sampler2D inputImageTexture;\n" +
+            " varying highp vec2 textureCoordinate;\n" +
+            " \n" +
+            " uniform lowp float shadows;\n" +
+            " uniform lowp float highlights;\n" +
+            " \n" +
+            " const mediump vec3 luminanceWeighting = vec3(0.3, 0.3, 0.3);\n" +
+            " \n" +
+            " void main()\n" +
+            " {\n" +
+            "   lowp vec4 source = texture2D(inputImageTexture, textureCoordinate);\n" +
+            "   mediump float luminance = dot(source.rgb, luminanceWeighting);\n" +
+            " \n" +
+            "   mediump float shadow = clamp((pow(luminance, 1.0/shadows) + (-0.76)*pow(luminance, 2.0/shadows)) - luminance, 0.0, 1.0);\n" +
+            "   mediump float highlight = clamp((1.0 - (pow(1.0-luminance, 1.0/(2.0-highlights)) + (-0.8)*pow(1.0-luminance, 2.0/(2.0-highlights)))) - luminance, -1.0, 0.0);\n" +
+            "   lowp vec3 result = vec3(0.0, 0.0, 0.0) + ((luminance + shadow + highlight) - 0.0) * ((source.rgb - vec3(0.0, 0.0, 0.0))/(luminance - 0.0));\n" +
+            " \n" +
+            "   mediump float contrastedLuminance = ((luminance - 0.5) * 1.5) + 0.5;\n" +
+            "   mediump float whiteInterp = contrastedLuminance*contrastedLuminance*contrastedLuminance;\n" +
+            "   mediump float whiteTarget = clamp(highlights, 1.0, 2.0) - 1.0;\n" +
+            "   result = mix(result, vec3(1.0), whiteInterp*whiteTarget);\n" +
+            " \n" +
+            "   mediump float invContrastedLuminance = 1.0 - contrastedLuminance;\n" +
+            "   mediump float blackInterp = invContrastedLuminance*invContrastedLuminance*invContrastedLuminance;\n" +
+            "   mediump float blackTarget = 1.0 - clamp(shadows, 0.0, 1.0);\n" +
+            "   result = mix(result, vec3(0.0), blackInterp*blackTarget);\n" +
+            " \n" +
+            "   gl_FragColor = vec4(result, source.a);\n" +
+            " }";
+
+
+    private int shadowsLocation;
+    private float shadows;
+    private int highlightsLocation;
+    private float highlights;
+
+    public GPUImageHighlightShadowWideRangeFilter() {
+        this(1.0f, 1.0f);
+    }
+
+    public GPUImageHighlightShadowWideRangeFilter(final float shadows, final float highlights) {
+        super(NO_FILTER_VERTEX_SHADER, HIGHLIGHT_SHADOW_FRAGMENT_SHADER);
+        this.highlights = highlights;
+        this.shadows = shadows;
+    }
+
+    @Override
+    public void onInit() {
+        super.onInit();
+        highlightsLocation = GLES20.glGetUniformLocation(getProgram(), "highlights");
+        shadowsLocation = GLES20.glGetUniformLocation(getProgram(), "shadows");
+    }
+
+    @Override
+    public void onInitialized() {
+        super.onInitialized();
+        setHighlights(highlights);
+        setShadows(shadows);
+    }
+
+    public void setHighlights(final float highlights) {
+        this.highlights = highlights;
+        setFloat(highlightsLocation, this.highlights);
+    }
+
+    public void setShadows(final float shadows) {
+        this.shadows = shadows;
+        setFloat(shadowsLocation, this.shadows);
+    }
+}

--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageHighlightWideRangeFilter.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageHighlightWideRangeFilter.java
@@ -1,0 +1,17 @@
+package jp.co.cyberagent.android.gpuimage.filter;
+
+/**
+ * Adjusts the highlights of an image
+ * highlights: Decrease to darken highlights, from 0.0 to 1.0, with 1.0 as the default.
+ */
+public class GPUImageHighlightWideRangeFilter extends GPUImageHighlightShadowWideRangeFilter {
+
+    public GPUImageHighlightWideRangeFilter() {
+        super(1.0f, 1.0f);
+    }
+
+    public GPUImageHighlightWideRangeFilter(final float highlights) {
+        super(1.0f, highlights);
+    }
+
+}

--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageShadowWideRangeFilter.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageShadowWideRangeFilter.java
@@ -1,0 +1,18 @@
+package jp.co.cyberagent.android.gpuimage.filter;
+
+/**
+ * Adjusts the shadows of an image
+ * shadows: Increase to lighten shadows, from 0.0 to 2.0, with 1.0 as the default.ult.
+ */
+public class GPUImageShadowWideRangeFilter extends GPUImageHighlightShadowWideRangeFilter {
+
+    public GPUImageShadowWideRangeFilter() {
+        super(1.0f, 1.0f);
+    }
+
+    public GPUImageShadowWideRangeFilter(final float shadows) {
+        super(shadows, 1.0f);
+    }
+
+}
+

--- a/sample/src/main/java/jp/co/cyberagent/android/gpuimage/sample/GPUImageFilterTools.kt
+++ b/sample/src/main/java/jp/co/cyberagent/android/gpuimage/sample/GPUImageFilterTools.kt
@@ -30,6 +30,11 @@ object GPUImageFilterTools {
         listener: (filter: GPUImageFilter) -> Unit
     ) {
         val filters = FilterList().apply {
+
+            addFilter("Exposure", FilterType.EXPOSURE)
+            addFilter("Highlight Shadow", FilterType.HIGHLIGHT_SHADOW)
+            addFilter("Highlight", FilterType.HIGHLIGHT)
+            addFilter("Shadow", FilterType.SHADOW)
             addFilter("Contrast", FilterType.CONTRAST)
             addFilter("Invert", FilterType.INVERT)
             addFilter("Pixelation", FilterType.PIXELATION)
@@ -46,8 +51,7 @@ object GPUImageFilterTools {
             addFilter("Posterize", FilterType.POSTERIZE)
             addFilter("Grouped filters", FilterType.FILTER_GROUP)
             addFilter("Saturation", FilterType.SATURATION)
-            addFilter("Exposure", FilterType.EXPOSURE)
-            addFilter("Highlight Shadow", FilterType.HIGHLIGHT_SHADOW)
+
             addFilter("Monochrome", FilterType.MONOCHROME)
             addFilter("Opacity", FilterType.OPACITY)
             addFilter("RGB", FilterType.RGB)
@@ -154,11 +158,21 @@ object GPUImageFilterTools {
                 )
             )
             FilterType.SATURATION -> GPUImageSaturationFilter(1.0f)
+
             FilterType.EXPOSURE -> GPUImageExposureFilter(0.0f)
+
             FilterType.HIGHLIGHT_SHADOW -> GPUImageHighlightShadowFilter(
                 0.0f,
                 1.0f
             )
+
+            FilterType.HIGHLIGHT -> GPUImageHighlightWideRangeFilter(
+                    1.0f
+            )
+            FilterType.SHADOW -> GPUImageShadowWideRangeFilter(
+                    1.0f
+            )
+
             FilterType.MONOCHROME -> GPUImageMonochromeFilter(
                 1.0f, floatArrayOf(0.6f, 0.45f, 0.3f, 1.0f)
             )
@@ -326,7 +340,7 @@ object GPUImageFilterTools {
 
     private enum class FilterType {
         CONTRAST, GRAYSCALE, SHARPEN, SEPIA, SOBEL_EDGE_DETECTION, THRESHOLD_EDGE_DETECTION, THREE_X_THREE_CONVOLUTION, FILTER_GROUP, EMBOSS, POSTERIZE, GAMMA, BRIGHTNESS, INVERT, HUE, PIXELATION,
-        SATURATION, EXPOSURE, HIGHLIGHT_SHADOW, MONOCHROME, OPACITY, RGB, WHITE_BALANCE, VIGNETTE, TONE_CURVE, LUMINANCE, LUMINANCE_THRESHSOLD, BLEND_COLOR_BURN, BLEND_COLOR_DODGE, BLEND_DARKEN,
+        SATURATION, EXPOSURE, HIGHLIGHT_SHADOW, HIGHLIGHT, SHADOW, MONOCHROME, OPACITY, RGB, WHITE_BALANCE, VIGNETTE, TONE_CURVE, LUMINANCE, LUMINANCE_THRESHSOLD, BLEND_COLOR_BURN, BLEND_COLOR_DODGE, BLEND_DARKEN,
         BLEND_DIFFERENCE, BLEND_DISSOLVE, BLEND_EXCLUSION, BLEND_SOURCE_OVER, BLEND_HARD_LIGHT, BLEND_LIGHTEN, BLEND_ADD, BLEND_DIVIDE, BLEND_MULTIPLY, BLEND_OVERLAY, BLEND_SCREEN, BLEND_ALPHA,
         BLEND_COLOR, BLEND_HUE, BLEND_SATURATION, BLEND_LUMINOSITY, BLEND_LINEAR_BURN, BLEND_SOFT_LIGHT, BLEND_SUBTRACT, BLEND_CHROMA_KEY, BLEND_NORMAL, LOOKUP_AMATORKA,
         GAUSSIAN_BLUR, CROSSHATCH, BOX_BLUR, CGA_COLORSPACE, DILATION, KUWAHARA, RGB_DILATION, SKETCH, TOON, SMOOTH_TOON, BULGE_DISTORTION, GLASS_SPHERE, HAZE, LAPLACIAN, NON_MAXIMUM_SUPPRESSION,
@@ -362,8 +376,14 @@ object GPUImageFilterTools {
                 is GPUImagePosterizeFilter -> PosterizeAdjuster(filter)
                 is GPUImagePixelationFilter -> PixelationAdjuster(filter)
                 is GPUImageSaturationFilter -> SaturationAdjuster(filter)
+
                 is GPUImageExposureFilter -> ExposureAdjuster(filter)
+
                 is GPUImageHighlightShadowFilter -> HighlightShadowAdjuster(filter)
+
+                is GPUImageHighlightWideRangeFilter -> HighlightAdjuster(filter)
+                is GPUImageShadowWideRangeFilter -> ShadowAdjuster(filter)
+
                 is GPUImageMonochromeFilter -> MonochromeAdjuster(filter)
                 is GPUImageOpacityFilter -> OpacityAdjuster(filter)
                 is GPUImageRGBFilter -> RGBAdjuster(filter)
@@ -514,7 +534,8 @@ object GPUImageFilterTools {
         private inner class ExposureAdjuster(filter: GPUImageExposureFilter) :
             Adjuster<GPUImageExposureFilter>(filter) {
             override fun adjust(percentage: Int) {
-                filter.setExposure(range(percentage, -10.0f, 10.0f))
+                var value = range(percentage, -1.0f, 1.0f)
+                filter.setExposure(value)
             }
         }
 
@@ -523,6 +544,20 @@ object GPUImageFilterTools {
             override fun adjust(percentage: Int) {
                 filter.setShadows(range(percentage, 0.0f, 1.0f))
                 filter.setHighlights(range(percentage, 0.0f, 1.0f))
+            }
+        }
+
+        private inner class HighlightAdjuster(filter: GPUImageHighlightWideRangeFilter) :
+                Adjuster<GPUImageHighlightWideRangeFilter>(filter) {
+            override fun adjust(percentage: Int) {
+                filter.setHighlights(range(percentage, 0.0f, 2.0f))
+            }
+        }
+
+        private inner class ShadowAdjuster(filter: GPUImageShadowWideRangeFilter) :
+                Adjuster<GPUImageShadowWideRangeFilter>(filter) {
+            override fun adjust(percentage: Int) {
+                filter.setShadows(range(percentage, 0.0f, 2.0f))
             }
         }
 


### PR DESCRIPTION
…mage.

  - shadows: from 0.0 to 2.0, with 1.0 as the default.
  - highlights: from 0.0 to 2.0, with 1.0 as the default.

## What does this change?
You can adjust the highlights and shadows of an image in a wide range.

## What is the value of this and can you measure success?
I added the following new filters to the sample app.

- Shadows
- Hightlights

and check my changes.

## Screenshots

