### PR TITLE
Update GPUImageZoomBlurFilter.java

### DIFF
--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageZoomBlurFilter.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageZoomBlurFilter.java
@@ -66,6 +66,6 @@ public class GPUImageZoomBlurFilter extends GPUImageFilter {
 
     public void setBlurSize(final float blurSize) {
         this.blurSize = blurSize;
-        setFloat(blurSizeLocation, blurSizeLocation);
+        setFloat(blurSizeLocation, blurSize);
     }
 }


### PR DESCRIPTION
Fixed blur not updating on changing blurSize by correcting an incorrect argument passed to the setFloat() method inside setBlurSize() method.