### PR TITLE
Fixed an error in bitmap padding adding for width to have even value

### DIFF
--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImageRenderer.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImageRenderer.java
@@ -239,6 +239,7 @@ public class GPUImageRenderer implements GLSurfaceView.Renderer, GLTextureView.R
                 if (bitmap.getWidth() % 2 == 1) {
                     resizedBitmap = Bitmap.createBitmap(bitmap.getWidth() + 1, bitmap.getHeight(),
                             Bitmap.Config.ARGB_8888);
+					resizedBitmap.setDensity(bitmap.getDensity());
                     Canvas can = new Canvas(resizedBitmap);
                     can.drawARGB(0x00, 0x00, 0x00, 0x00);
                     can.drawBitmap(bitmap, 0, 0, null);

--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImageRenderer.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImageRenderer.java
@@ -239,7 +239,7 @@ public class GPUImageRenderer implements GLSurfaceView.Renderer, GLTextureView.R
                 if (bitmap.getWidth() % 2 == 1) {
                     resizedBitmap = Bitmap.createBitmap(bitmap.getWidth() + 1, bitmap.getHeight(),
                             Bitmap.Config.ARGB_8888);
-					resizedBitmap.setDensity(bitmap.getDensity());
+                    resizedBitmap.setDensity(bitmap.getDensity());
                     Canvas can = new Canvas(resizedBitmap);
                     can.drawARGB(0x00, 0x00, 0x00, 0x00);
                     can.drawBitmap(bitmap, 0, 0, null);


### PR DESCRIPTION
## What does this change?
In _setImageBitmap_ method of _GPUImageRenderer_ the bitmap is resized to have even width. A canvas is constructed to draw to newly created bitmap with additional row: first canvas is fiiled with black and then original bitmap is drawn.
The problem is that a density of the created bitmap is implicitly set to the density of the current display (according to the _createBitmap_ method [docs](https://developer.android.com/reference/android/graphics/Bitmap.html#createBitmap(int,%20int,%20android.graphics.Bitmap.Config))) and canvas receives bitmap's density while source bitmap has its own density and is automatically scaled when _drawBitmap_ method called (as stated in _drawBitmap_ [docs](https://developer.android.com/reference/android/graphics/Canvas.html#drawBitmap(android.graphics.Bitmap,%20float,%20float,%20android.graphics.Paint))). This results in that only piece of the source image is drawn to canvas.
The workaround is to set resized bitmap density to be equal to source bitmap density.

## What is the value of this and can you measure success?
As a result of the fix a padding row is added correctly.

