### PR TITLE
fix Camera2Loader, replace or with ||

### DIFF
--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImageRenderer.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImageRenderer.java
@@ -300,6 +300,11 @@ public class GPUImageRenderer implements GLSurfaceView.Renderer, GLTextureView.R
                     addDistance(textureCords[6], distHorizontal), addDistance(textureCords[7], distVertical),
             };
         } else {
+            if (rotation == Rotation.ROTATION_270 || rotation == Rotation.ROTATION_90) {
+                ratioWidth  = ratioWidth + ratioHeight;
+                ratioHeight = ratioWidth - ratioHeight;
+                ratioWidth  = ratioWidth - ratioHeight;
+            }
             cube = new float[]{
                     CUBE[0] / ratioHeight, CUBE[1] / ratioWidth,
                     CUBE[2] / ratioHeight, CUBE[3] / ratioWidth,

--- a/sample/src/main/java/jp/co/cyberagent/android/gpuimage/sample/utils/Camera2Loader.kt
+++ b/sample/src/main/java/jp/co/cyberagent/android/gpuimage/sample/utils/Camera2Loader.kt
@@ -125,8 +125,8 @@ class Camera2Loader(private val activity: Activity) : CameraLoader() {
             ?.getOutputSizes(ImageFormat.YUV_420_888)
 
         val orientation = getCameraOrientation()
-        val maxPreviewWidth = if (orientation == 90 or 270) viewHeight else viewWidth
-        val maxPreviewHeight = if (orientation == 90 or 270) viewWidth else viewHeight
+        val maxPreviewWidth = if (orientation == 90 || orientation == 270) viewHeight else viewWidth
+        val maxPreviewHeight = if (orientation == 90 || orientation == 270) viewWidth else viewHeight
 
         return outputSizes?.filter {
             it.width < maxPreviewWidth / 2 && it.height < maxPreviewHeight / 2


### PR DESCRIPTION
if (rotation == 90 or 270) should be replaced by if (rotation == 90 || rotation == 270), otherwise it will always be false and you will find something wrong when you switch camera


