### PR TITLE
Add texel spacing multiplier for Bilateral blur filter

### DIFF
--- a/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageBilateralBlurFilter.java
+++ b/library/src/main/java/jp/co/cyberagent/android/gpuimage/filter/GPUImageBilateralBlurFilter.java
@@ -113,6 +113,7 @@ public class GPUImageBilateralBlurFilter extends GPUImageFilter {
     private float distanceNormalizationFactor;
     private int disFactorLocation;
     private int singleStepOffsetLocation;
+    private float texelSpacingMultiplier;
 
     public GPUImageBilateralBlurFilter() {
         this(8.0f);
@@ -121,6 +122,7 @@ public class GPUImageBilateralBlurFilter extends GPUImageFilter {
     public GPUImageBilateralBlurFilter(final float distanceNormalizationFactor) {
         super(BILATERAL_VERTEX_SHADER, BILATERAL_FRAGMENT_SHADER);
         this.distanceNormalizationFactor = distanceNormalizationFactor;
+        this.texelSpacingMultiplier = 4.0f;
     }
 
     @Override
@@ -142,7 +144,12 @@ public class GPUImageBilateralBlurFilter extends GPUImageFilter {
     }
 
     private void setTexelSize(final float w, final float h) {
-        setFloatVec2(singleStepOffsetLocation, new float[]{1.0f / w, 1.0f / h});
+        setFloatVec2(singleStepOffsetLocation, new float[]{texelSpacingMultiplier / w, texelSpacingMultiplier / h});
+    }
+
+    public void setTexelSpacingMultiplier(float texelSpacingMultiplier) {
+        this.texelSpacingMultiplier = texelSpacingMultiplier;
+        setTexelSize(getOutputWidth(), getOutputHeight());
     }
 
     @Override


### PR DESCRIPTION
## What does this change?
Add a texel spacing multiplier variable to class GPUImageBilateralBlurFilter

## What is the value of this and can you measure success?
This makes the Bilateral blur more flexible and clear. A larger texel spacing (i.e. 4.0f) instead of only 1.0f like current.

## Screenshots

![Screenshot_1621273179](https://user-images.githubusercontent.com/32135551/118533767-a823b800-b772-11eb-9126-3f0c8531ceb4.png)
![Screenshot_1621273199](https://user-images.githubusercontent.com/32135551/118533782-ace86c00-b772-11eb-8cf0-598d0cd9f0a3.png)
